### PR TITLE
chore: release v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7](https://github.com/nyurik/sqlite-compressions/compare/v0.3.6...v0.3.7) - 2025-06-08
+
+### Other
+
+- remove default ci perms
+
 ## [0.3.6](https://github.com/nyurik/sqlite-compressions/compare/v0.3.5...v0.3.6) - 2025-06-08
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,7 +982,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "sqlite-compressions"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "brotli",
  "bsdiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlite-compressions"
 # This value is also used in the README.md
-version = "0.3.6"
+version = "0.3.7"
 description = "Compression, decompression, testing, diffing and patching functions for SQLite: gzip, brotli, bsdiff, ..."
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/sqlite-compressions"


### PR DESCRIPTION



## 🤖 New release

* `sqlite-compressions`: 0.3.6 -> 0.3.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.7](https://github.com/nyurik/sqlite-compressions/compare/v0.3.6...v0.3.7) - 2025-06-08

### Other

- remove default ci perms
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).