### PR TITLE
chore: release v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8](https://github.com/nyurik/sqlite-compressions/compare/v0.3.7...v0.3.8) - 2025-08-23
+
+### Other
+
+- update dependencies ([#122](https://github.com/nyurik/sqlite-compressions/pull/122))
+- format Cargo.toml, minor just cleanup ([#121](https://github.com/nyurik/sqlite-compressions/pull/121))
+- [pre-commit.ci] pre-commit autoupdate ([#118](https://github.com/nyurik/sqlite-compressions/pull/118))
+- use release-plz token in dependabot ci
+
 ## [0.3.7](https://github.com/nyurik/sqlite-compressions/compare/v0.3.6...v0.3.7) - 2025-06-08
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,7 +969,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "sqlite-compressions"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "brotli",
  "bsdiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlite-compressions"
 # This value is also used in the README.md
-version = "0.3.7"
+version = "0.3.8"
 description = "Compression, decompression, testing, diffing and patching functions for SQLite: gzip, brotli, bsdiff, ..."
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/sqlite-compressions"


### PR DESCRIPTION



## 🤖 New release

* `sqlite-compressions`: 0.3.7 -> 0.3.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.8](https://github.com/nyurik/sqlite-compressions/compare/v0.3.7...v0.3.8) - 2025-08-23

### Other

- update dependencies ([#122](https://github.com/nyurik/sqlite-compressions/pull/122))
- format Cargo.toml, minor just cleanup ([#121](https://github.com/nyurik/sqlite-compressions/pull/121))
- [pre-commit.ci] pre-commit autoupdate ([#118](https://github.com/nyurik/sqlite-compressions/pull/118))
- use release-plz token in dependabot ci
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).