### PR TITLE
chore: release v0.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.12](https://github.com/nyurik/sqlite-compressions/compare/v0.3.11...v0.3.12) - 2026-06-23
+
+### Other
+
+- update lock to latest
+- update .gitignore
+- format justfile
+- *(deps)* bump the all-actions-version-updates group with 3 updates ([#146](https://github.com/nyurik/sqlite-compressions/pull/146))
+- *(deps)* bump log from 0.4.32 to 0.4.33 in the all-cargo-version-updates group ([#145](https://github.com/nyurik/sqlite-compressions/pull/145))
+- justfile cleanup
+
 ## [0.3.11](https://github.com/nyurik/sqlite-compressions/compare/v0.3.10...v0.3.11) - 2026-06-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "sqlite-compressions"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "brotli",
  "bsdiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlite-compressions"
 # This value is also used in the README.md
-version = "0.3.11"
+version = "0.3.12"
 description = "Compression, decompression, testing, diffing and patching functions for SQLite: gzip, brotli, bsdiff, ..."
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/sqlite-compressions"


### PR DESCRIPTION



## 🤖 New release

* `sqlite-compressions`: 0.3.11 -> 0.3.12 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.12](https://github.com/nyurik/sqlite-compressions/compare/v0.3.11...v0.3.12) - 2026-06-23

### Other

- update lock to latest
- update .gitignore
- format justfile
- *(deps)* bump the all-actions-version-updates group with 3 updates ([#146](https://github.com/nyurik/sqlite-compressions/pull/146))
- *(deps)* bump log from 0.4.32 to 0.4.33 in the all-cargo-version-updates group ([#145](https://github.com/nyurik/sqlite-compressions/pull/145))
- justfile cleanup
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).